### PR TITLE
Replace GH_TOKEN with JF_BOT_TOKEN

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -33,9 +33,9 @@ jobs:
         run: rm dist/studios/**/studio.json
       - name: Compress built assets
         run: cd dist; zip -r -D ../release.zip *; cd ..
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: "marvinpinto/action-automatic-releases@v1.2.0"
         with:
-          repo_token: "${{ secrets.GH_TOKEN }}"
+          repo_token: "${{ secrets.JF_BOT_TOKEN }}"
           automatic_release_tag: "latest"
           prerelease: false
           files: |

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Validate studios.json
         uses: snapcart/json-schema-validator@v1.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.JF_BOT_TOKEN }}
           json_schema: .github/studios.schema.json
           json_path_pattern: studios/.*/studio.json$


### PR DESCRIPTION
``GH_TOKEN`` seems to be used internally by GitHub and it's making some actions we're using in some repos fail ([Source](https://github.com/alex-page/github-project-automation-plus/issues/39))

*(PRs made from users of the org are always successful, but PRs that aren't don't work, like Dependabot PRs. This can be checked by looking at the history of server repos and Jellyfin Vue)*

The org-wide secret should be renamed to something else to avoid confusion and further replacements or messes in GH's side. This PR replaces ``GH_TOKEN`` with ``JF_BOT_TOKEN``, which should be pretty generic.