### PR TITLE
Update plugin link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@
 
 This repository provides the sources for the artwork served by the Jellyfin Artwork Repository. It contains images for Studios, Networks, Music Labels, and Genres.
 
-It should be used with the [Jellyfin Artwork Plugin](https://github.com/crobibero/jellyfin-plugin-artwork)
+It should be used with the [Jellyfin Artwork Plugin](https://github.com/jellyfin/jellyfin-plugin-artwork)


### PR DESCRIPTION
The plugin was moved to the Jellyfin organization some time ago. Update the README to reflect that change.